### PR TITLE
Ignored views still rendered when report is created from layout file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.3.3a2
+ - Corrected bug where views listed in the `ignore_views` key from layout file 
+   were still getting rendered 
+
 ## v0.3.3a1
  - Added tests and added CI on Travis
  - Added `Report.write` to write rendered output to files

--- a/dbreport/__init__.py
+++ b/dbreport/__init__.py
@@ -1,7 +1,7 @@
 """Generator for SQLite database"""
 from .dbreport import Report
 
-__version__ = "0.3.3a1"
+__version__ = "0.3.3a2"
 __author__ = "Joseph Contreras Jr."
 __license__ = "MIT"
 __copyright__ = "Copyright 2018 Joseph Contreras Jr."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2019, Joseph Contreras'
 author = 'Joseph Contreras'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.3a1'
+release = '0.3.3a2'
 
 # add this to specifically use index.rst rather then contents.rst to avoid
 # errors when building on RTD

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ paths = ['templates/' + p for p in paths]
 
 setup(
     name='dbreport',
-    version='0.3.3a1',
+    version='0.3.3a2',
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/dbreport/conftest.py
+++ b/tests/dbreport/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3 as sq3
 from datetime import datetime
@@ -22,7 +23,6 @@ def patch_datetime(monkeypatch, datetime_constant):
             return datetime_constant
 
     monkeypatch.setattr("dbreport.dbreport.datetime", mydatetime)
-
 
 
 @pytest.fixture(scope="session")
@@ -113,3 +113,22 @@ def get_columns(*args, **kwargs):
         return cols
 
     return columns
+
+
+@pytest.fixture(scope="session")
+def report_from_layout(db_connection):
+    """
+    create layout file and yield the path
+
+    Delete the file on clean-up
+    """
+    path = os.path.abspath(os.path.join(".", "layout.json"))
+    layout = {
+        "paths": {"database": TEST_PATH, "report_dir": "."},
+        "ignore_views": ["popularArtists"],
+    }
+    with open(path, "w") as f:
+        f.write(json.dumps(layout))
+    report = Report(path)
+    yield report, layout
+    os.remove(path)

--- a/tests/dbreport/test_dbreport.py
+++ b/tests/dbreport/test_dbreport.py
@@ -158,3 +158,12 @@ def test_write(report, rendered_reports, datetime_constant):
 def test_write_invalid_report_path(report):
     with pytest.raises(NotADirectoryError):
         report.write("not_a_directory")
+
+
+def test_layout_ignore_views(report_from_layout):
+    report, layout = report_from_layout
+    reports = report.render()
+    ignore_view = 'popularArtists'
+    assert (
+            ignore_view not in reports.keys()
+    ), f"ignored view '{ignore_view}' was still rendered"


### PR DESCRIPTION
This pull request fixes the bug in issue #3, where views listed in the `ignore_views` key of the layout file were still rendered.

This pull request updates how the `ignore` property is instantiated so that it is set for both keyword arguments, and the layout file.